### PR TITLE
Filter out .sha256 URLs from GH release page

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1364,6 +1364,11 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh"
         [[ ${#list2} -gt 0 ]] && list=( ${list2[@]} )
     }
 
+    [[ ${#list} -gt 1 ]] && {
+        list2=( ${list[@]:#(#i)*.sha256} )
+        [[ ${#list2} -gt 0 ]] && list=( ${list2[@]} )
+    }
+
     [[ $#list -eq 0 ]] && {
         print -nr "${ZINIT[col-msg2]}Didn't find correct Github" \
             "release-file to download"


### PR DESCRIPTION
When it tries to download from github release page it downloads the `.sha256` file.
This PR simply filter those URLs out but maybe there are more generic/elegant way to do it.

I got the problem on this page: https://github.com/starship/starship/releases/tag/v0.37.0.

zinit config:
```
zinit ice from"gh-r" as"program" pick"**/starship" \
    atload"!eval \$(starship init zsh)"
zinit load starship/starship
```