### PR TITLE
Update of the {auto} formatter / again no docs :/

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,10 +2,12 @@ name: Documentation
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - 'zinit*.zsh'
   push:
-    branchs:
+    branches:
       - main
   workflow_dispatch:
 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -1068,7 +1068,7 @@ ____
  User-action entry point.
 ____
 
-Has 44 line(s). Calls functions:
+Has 42 line(s). Calls functions:
 
  .zinit-self-update
  |-- zinit.zsh/+zinit-message

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -711,16 +711,17 @@ ZINIT[EXTENDED_GLOB]=""
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal
 
-    [[ $1 = -q ]] && +zinit-message -n "{pre}[self-update]{msg2} Updating Zinit repository{msg2}" \
+    [[ $1 = -q ]] && +zinit-message "{pre}[self-update]{info} updating zinit repository{msg2}" \
 
     local nl=$'\n' escape=$'\x1b['
-    local current_branch=$(builtin pushd $ZINIT[BIN_DIR] > /dev/null && git branch --show-current && popd > /dev/null)
+    local current_branch=$(git -C $ZINIT[BIN_DIR] rev-parse --abbrev-ref HEAD)
+    # local current_branch='main'
     local -a lines
     (
         builtin cd -q "$ZINIT[BIN_DIR]" \
-        && +zinit-message -n "{pre}[self-update]{info} fetching latest changes from {cmd}$current_branch$nl{rst}" \
+        && +zinit-message -n "{pre}[self-update]{info} fetching latest changes from {obj}$current_branch{info} branch$nl{rst}" \
         && command git fetch --quiet \
-        && lines=( ${(f)"$(command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset || %b' ..FETCH_HEAD)"} )
+        && lines=( ${(f)"$(command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset || %b' ..origin/HEAD)"} )
         if (( ${#lines} > 0 )); then
             # Remove the (origin/main ...) segments, to expect only tags to appear
             lines=( "${(S)lines[@]//\(([,[:blank:]]#(origin|HEAD|master|main)[^a-zA-Z]##(HEAD|origin|master|main)[,[:blank:]]#)#\)/}" )
@@ -743,16 +744,16 @@ ZINIT[EXTENDED_GLOB]=""
         }
     )
     if [[ $1 != -q ]] {
-        +zinit-message "{pre}[self-update]{info} compiling zinit via {cmd}zcompile{rst}"
+        +zinit-message "{pre}[self-update]{info} compiling zinit via {obj}zcompile{rst}"
     }
     command rm -f $ZINIT[BIN_DIR]/*.zwc(DN)
     zcompile -U $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload','additional'}.zsh
     zcompile -U $ZINIT[BIN_DIR]/share/git-process-output.zsh
     # Load for the current session
-    [[ $1 != -q ]] && +zinit-message "{pre}[self-update]{info} Reloading Zinit for the current session{rst}"
+    [[ $1 != -q ]] && +zinit-message "{pre}[self-update]{info} reloading zinit for the current session{rst}"
 
-    +zinit-message "{pre}self-update: {msg2}Resetting the repository with command:{rst} ${ICE[reset]:-git reset --hard HEAD} {…}"
+    # +zinit-message "{pre}[self-update]{info} resetting zinit repository via{rst}: {cmd}${ICE[reset]:-git reset --hard HEAD}{rst}"
     source $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload'}.zsh
     # Read and remember the new modification timestamps


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The update does  the following:
1. It makes `a/b` strings be recognized as plugin ids (plus the previous way of recognition via a test to the disk, for single-word id-as plugins).
2. It makes ices with values that contain spaces correctly handled.
3. It makes Oh My Zsh shrothands like `OMZP:`,`OMZL`, etc. recognized as plugin ids.
4. It colorizes numbers with {num}  and time notions (like, e.g.: `3s`) with a new code {time} (color 220 – gold).

<!--- Describe your changes in detail -->

## Motivation and Context

The {auto} formatter does an useful job of colorizing text messages, however the lack of space support and of regular plugin ids and nums/times was a serious drawback.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

<!--- Provide examples of intended usage -->

```zsh
+ziinit-message '{auto}Plugin a/b installed in 10s'
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

# Tests
Despite that I'm now on a bigger machine than Eee PC (core i5), I cannot run the doc/container target because there isn't any docker binary available for PC Linux OS that I'm using. **Sorry** for this, I've really checked Google and tried installing the official RPMs, however they didn't install/yield  a working docker.
